### PR TITLE
Add xRegistry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # iCalendar
+[![Registry](https://img.shields.io/badge/Registry-SpecWorks-blue)](https://spec-works.github.io/registry/parts/icalendar/)
+
 
 Software component for parsing, validating, and serializing iCalendar (text/calendar) data.
 

--- a/specs.json
+++ b/specs.json
@@ -47,6 +47,11 @@
       "type": "text/html",
       "rel": "related",
       "title": "IANA Media Type Registration for text/calendar"
+    },
+    {
+      "rel": "registry",
+      "title": "Part registry entry",
+      "href": "https://spec-works.github.io/registry/parts/icalendar/"
     }
   ]
 }


### PR DESCRIPTION
Adds xRegistry links for specification-centric component discovery.

## Changes

- **specs.json**: Added registry link (rel: registry)
- **README.md**: Added registry badge

## Registry Entry

This part is now discoverable in the SpecWorks registry.

## Related

- spec-works/specification#6 (Deploy xRegistry using GitHub Pages)
- Phase 5: Integration with parts